### PR TITLE
Dotnet samples with customViewerData field

### DIFF
--- a/src/dotnet/CSharp.SelfSignJwtTracking/Program.cs
+++ b/src/dotnet/CSharp.SelfSignJwtTracking/Program.cs
@@ -140,3 +140,35 @@ Console.WriteLine("SST with Custom TrackingID: " + selfSignTokenWithCustomTracki
 }
  */
 
+
+
+var sampleTokenWithCustomViewerData = JsonSerializer.Deserialize<SampleSubscribeToken>(File.OpenRead("../../../../../sample-json/sampleSST.json"));
+if (sampleTokenWithCustomViewerData is null)
+{
+    throw new Exception("bad sample json");
+}
+
+var selfSignTokenWithCustomViewerData = tokenGenerator.CreateToken(sampleTokenWithCustomViewerData.tokenId,
+    sampleTokenWithCustomViewerData.token,
+    sampleTokenWithCustomViewerData.streams.First().streamName,
+    customViewerData: "uniqueViewer1234");
+
+Console.WriteLine("SST With customViewerData: "+ selfSignTokenWithCustomViewerData);
+
+// Example JWT payload, when we don't set a TrackingID (and the Master Subscribe Token doesn't have Tracking)
+/*
+ * {
+  "streaming": {
+    "tokenId": 1,
+    "tokenType": "Subscribe",
+    "streamName": "testStream",
+    "allowedOrigins": [],
+    "allowedIpAddresses": [],
+    "tracking": null,
+    "customViewerData": "uniqueViewer1234"
+  },
+  "nbf": 1673934423,
+  "exp": 1673934483,
+  "iat": 1673934423
+}
+ */

--- a/src/dotnet/CSharp.SelfSignJwtTracking/Program.cs
+++ b/src/dotnet/CSharp.SelfSignJwtTracking/Program.cs
@@ -14,7 +14,7 @@ if (sampleTokenWithNoParentTracking is null)
 var selfSignTokenWithNoTracking = tokenGenerator.CreateToken(sampleTokenWithNoParentTracking.tokenId,
     sampleTokenWithNoParentTracking.token,
     sampleTokenWithNoParentTracking.streams.First().streamName,
-    sampleTokenWithNoParentTracking.tracking, expiresIn: 99999999);
+    sampleTokenWithNoParentTracking.tracking);
 
 Console.WriteLine("SST With No Tracking enabled: "+ selfSignTokenWithNoTracking);
 
@@ -68,7 +68,7 @@ else
 var selfSignTokenWithParentTracking = tokenGenerator.CreateToken(sampleTokenWithParentTracking.tokenId,
     sampleTokenWithParentTracking.token,
     streamName,
-    sampleTokenWithParentTracking.tracking, expiresIn:99999999);
+    sampleTokenWithParentTracking.tracking);
 
 Console.WriteLine("SST With Parent Tracking: "+ selfSignTokenWithParentTracking);
 
@@ -117,7 +117,7 @@ else
 var customTrackingId = new Tracking("customTrackingId2");
 var selfSignTokenWithCustomTracking = tokenGenerator.CreateToken(sampleTokenWithCustomTrackingId.tokenId,
     sampleTokenWithCustomTrackingId.token,
-    streamName, customTrackingId,  expiresIn: 99999999);
+    streamName, customTrackingId);
 
 Console.WriteLine("SST with Custom TrackingID: " + selfSignTokenWithCustomTracking);
 

--- a/src/dotnet/CSharp.SelfSignJwtTracking/SampleSubscribeToken.cs
+++ b/src/dotnet/CSharp.SelfSignJwtTracking/SampleSubscribeToken.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Text.Json.Serialization;
 
 namespace CSharp.SelfSignJwtTracking;

--- a/src/dotnet/CSharp.SelfSignJwtTracking/TokenGenerator.cs
+++ b/src/dotnet/CSharp.SelfSignJwtTracking/TokenGenerator.cs
@@ -16,11 +16,13 @@ public class TokenGenerator
         _tokenHandler = new JwtSecurityTokenHandler();
     }
 
-    public string CreateToken(uint tokenId, string tokenString, string streamName, Tracking? tracking,
+    public string CreateToken(uint tokenId, string tokenString, string streamName,
+        Tracking? tracking = null,
         IEnumerable<string>? allowedOrigins = null, IEnumerable<string>? allowedIpAddresses = null,
-        int expiresIn = 60)
+        int expiresIn = 60,
+        string? customViewerData = null)
     {
-        var payload = new JwtPayload(tokenId, streamName, allowedOrigins, allowedIpAddresses, tracking);
+        var payload = new JwtPayload(tokenId, streamName, allowedOrigins, allowedIpAddresses, tracking, customViewerData);
 
         var tokenDescriptor = new SecurityTokenDescriptor()
         {
@@ -41,9 +43,10 @@ public class TokenGenerator
     {
         public StreamPayload streaming { get; }
 
-        public JwtPayload(uint tokenId, string streamName, IEnumerable<string>? allowedOrigins, IEnumerable<string>? allowedIpAddresses, Tracking? tracking)
+        public JwtPayload(uint tokenId, string streamName, IEnumerable<string>? allowedOrigins, IEnumerable<string>? allowedIpAddresses, Tracking? tracking,
+            string? customViewerData)
         {
-            this.streaming = new StreamPayload(tokenId, streamName, allowedOrigins, allowedIpAddresses, tracking);
+            this.streaming = new StreamPayload(tokenId, streamName, allowedOrigins, allowedIpAddresses, tracking, customViewerData);
         }
     }
 
@@ -61,13 +64,17 @@ public class TokenGenerator
         
         public Tracking? tracking { get; }
 
-        public StreamPayload(uint tokenId, string streamName, IEnumerable<string>? allowedOrigins, IEnumerable<string>? allowedIpAddresses, Tracking? tracking)
+        public string customViewerData { get; }
+
+        public StreamPayload(uint tokenId, string streamName, IEnumerable<string>? allowedOrigins, IEnumerable<string>? allowedIpAddresses, Tracking? tracking,
+            string? customViewerData)
         {
             this.tokenId = tokenId;
             this.streamName = streamName;
             this.allowedOrigins = allowedOrigins ?? Enumerable.Empty<string>();
             this.allowedIpAddresses = allowedIpAddresses ?? Enumerable.Empty<string>();
             this.tracking = tracking;
+            this.customViewerData = customViewerData;
         }
     }
 }

--- a/src/dotnet/CSharp.SelfSignJwtTracking/TokenGenerator.cs
+++ b/src/dotnet/CSharp.SelfSignJwtTracking/TokenGenerator.cs
@@ -23,6 +23,7 @@ public class TokenGenerator
         string? customViewerData = null)
     {
         var payload = new JwtPayload(tokenId, streamName, allowedOrigins, allowedIpAddresses, tracking, customViewerData);
+        ValidateStreamingPayload(payload.streaming);
 
         var tokenDescriptor = new SecurityTokenDescriptor()
         {
@@ -37,6 +38,14 @@ public class TokenGenerator
         var securityToken = _tokenHandler.CreateJwtSecurityToken(tokenDescriptor);
 
         return _tokenHandler.WriteToken(securityToken);
+    }
+
+    void ValidateStreamingPayload(StreamPayload streaming)
+    {
+        if (streaming.customViewerData is { Length: > Limits.CustomViewerData })
+        {
+            throw new Exception($"customViewerData cannot be longer than: {Limits.CustomViewerData}");
+        }
     }
 
     class JwtPayload
@@ -77,4 +86,9 @@ public class TokenGenerator
             this.customViewerData = customViewerData;
         }
     }
+}
+
+public static class Limits
+{
+    public const int CustomViewerData = 256;
 }

--- a/src/nodejs/node-tokengenerator/TokenGenerator.mjs
+++ b/src/nodejs/node-tokengenerator/TokenGenerator.mjs
@@ -26,7 +26,7 @@ export default class TokenGenerator {
    * @param {string[]=} allowedIpAddresses
    * @param {Tracking} tracking
    * @param {?number} [expiresIn = 60]
-   * @param {?string} customViewerData - Viewer data associated with connections using this token. Max length: 128
+   * @param {?string} customViewerData - Viewer data associated with connections using this token. Max length: 256
    * @returns {string}
    */
   createToken(tokenId, token, streamName,


### PR DESCRIPTION
Add customViewerData field to dotnet samples.
Include limit check for customViewerData.
Also updated nodejs code comment to specify customViewerData limit as 256.